### PR TITLE
Fixed bottom navbar position

### DIFF
--- a/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/MainActivity.kt
+++ b/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/MainActivity.kt
@@ -118,11 +118,11 @@ class MainActivity : AppCompatActivity() {
             .findFragmentById(R.id.fragment_container_view) as NavHostFragment
         val navController = navHostFragment.navController
 
-        activityMainBinding.bottomNavigation.setupWithNavController(navController)
+        contentMainBinding.bottomNavigation.setupWithNavController(navController)
 
         // Conditionally show the add_event_fragment item
         val isLoggedIn = intent.getBooleanExtra("isLoggedIn", false)
-        val bottomNavigationMenu = activityMainBinding.bottomNavigation.menu
+        val bottomNavigationMenu = contentMainBinding.bottomNavigation.menu
         val addEventMenuItem = bottomNavigationMenu.findItem(R.id.add_event_fragment)
         addEventMenuItem.isVisible = isLoggedIn
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -12,15 +12,4 @@
         android:id="@+id/content_main"
         layout="@layout/content_main" />
 
-    <!-- Bottom navigation bar with fragments -->
-    <com.google.android.material.bottomnavigation.BottomNavigationView
-        android:id="@+id/bottom_navigation"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom"
-        app:backgroundTint="?attr/colorPrimaryContainer"
-        app:itemIconTint="@color/bottom_nav_icon_color"
-        app:itemTextColor="?attr/colorOnPrimaryContainer"
-        app:menu="@menu/bottom_navigation_menu"/>
-
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -19,13 +19,11 @@
         app:layout_constraintTop_toTopOf="parent"
         app:title="@string/app_name"/>
 
-
-
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container_view"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/bottom_navigation"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/toolbar"
@@ -33,5 +31,18 @@
         app:defaultNavHost="true"
         app:navGraph="@navigation/nav_graph" />
 
+    <!-- Bottom navigation bar with fragments -->
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottom_navigation"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        app:backgroundTint="?attr/colorPrimaryContainer"
+        app:itemIconTint="@color/bottom_nav_icon_color"
+        app:itemTextColor="?attr/colorOnPrimaryContainer"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:menu="@menu/bottom_navigation_menu" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 🛠 Fix UI Bug: Bottom Navigation Bar Overlapping Content

### Issue  
The bottom navigation bar was overlapping UI elements such as the event list, making the last event partially hidden and preventing users from interacting with key elements like the "favorite" button.

### Root Cause  
The issue was due to incorrect placement of the `<BottomNavigationView>` in the layout hierarchy. It was initially declared in `activity_main.xml`, which caused constraints not to apply correctly to other views in `content_main.xml`.

### Solution  
Refactored the layout and binding logic to ensure proper constraint handling and visibility of all UI components.

### 🔧 Changes Made

- **Moved `<BottomNavigationView>`**  
  From `activity_main.xml` ➡️ `content_main.xml` for better layout containment and control.
  
- **Updated `MainActivity.kt`**  
  - Adjusted binding logic to reference `contentMainBinding` for the bottom navigation.
  - Updated menu setup and item selection to use the correct binding.

- **Modified `content_main.xml`**  
  - Added the `<BottomNavigationView>` at the bottom.
  - Adjusted the `FragmentContainerView` or other main content elements to have a bottom constraint above the navigation bar.

- **Cleaned up `activity_main.xml`**  
  - Removed the now-redundant bottom navigation view definition to avoid duplication or layout conflict.

### ✅ Result  
All UI content is now fully visible and scrollable. The bottom navigation bar no longer overlaps the last event, restoring correct user interaction.
