### PR TITLE
Fix EventLocation text bug

### DIFF
--- a/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/EventAdapter.kt
+++ b/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/EventAdapter.kt
@@ -59,7 +59,7 @@ class EventAdapter(
             // Format the timestamp into a readable date string
             val date = Date(event.eventDate)
             val formattedDate = SimpleDateFormat("dd MMM yyyy", Locale.getDefault()).format(date)
-            eventSubtitleTextView.text = context.getString(R.string.event_subtitle, formattedDate, event.eventLocation, event.eventType)
+            eventSubtitleTextView.text = context.getString(R.string.event_subtitle, formattedDate, event.eventLocation.address, event.eventType)
 
 
             eventDescriptionTextView.text = event.eventDescription


### PR DESCRIPTION
A very small pull request to fix the EventLocation bug, where it also displayed the coordinates for the location in the material card

### Changes to event subtitle formatting:
* [`app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/EventAdapter.kt`](diffhunk://#diff-32c7e905eb990043716b2d6abc405793b74ac4dd8d509383cfb26cf869ae1115L62-R62): Updated the `eventSubtitleTextView` to use `event.eventLocation.address` instead of `event.eventLocation`, ensuring that the address is displayed in the event subtitle.