### PR TITLE
Edit Image For Events

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,6 +76,8 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.core)
     implementation(libs.dotenv.kotlin)
 
+    implementation("com.github.bumptech.glide:glide:4.15.1")
+
     implementation(libs.okhttp)
     implementation(libs.logging.interceptor)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,8 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+
     <application
         android:name=".MyApplication"
         android:allowBackup="true"

--- a/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/EditEventFragment.kt
+++ b/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/EditEventFragment.kt
@@ -391,10 +391,24 @@ class EditEventFragment : BottomSheetDialogFragment() {
 
     private fun uploadPhotoAndSaveEvent() {
         val storageRef = FirebaseStorage.getInstance().reference
-        val photoRef = storageRef.child("event_photos/${UUID.randomUUID()}")
 
+        // Delete the old photo if it exists
+        val oldPhotoUrl = event.eventPhotoURL
+        if (oldPhotoUrl.isNotEmpty() && oldPhotoUrl.startsWith("https://")) {
+            val oldPhotoRef = storageRef.storage.getReferenceFromUrl(oldPhotoUrl)
+            oldPhotoRef.delete()
+                .addOnSuccessListener {
+                    showSnackbar("Old photo deleted successfully")
+                }
+                .addOnFailureListener { e ->
+                    showSnackbar("Failed to delete old photo: ${e.message}")
+                }
+        }
+
+        // Upload the new photo
+        val photoRef = storageRef.child("event_photos/${UUID.randomUUID()}")
         photoRef.putFile(imageUri!!)
-            .addOnSuccessListener { taskSnapshot ->
+            .addOnSuccessListener {
                 photoRef.downloadUrl.addOnSuccessListener { uri ->
                     saveEventWithPhotoUrl(uri.toString())
                 }

--- a/app/src/main/res/drawable/ic_image_error.xml
+++ b/app/src/main/res/drawable/ic_image_error.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorError">
+    <path
+        android:fillColor="@android:color/holo_red_light"
+        android:pathData="M21,5v6.59l-3,-3.01 -4,4.01 -4,-4 -4,4 -3,-3.01L3,5c0,-1.1 0.9,-2 2,-2h14c1.1,0 2,0.9 2,2zM18,11.42l3,3.01L21,19c0,1.1 -0.9,2 -2,2L5,21c-1.1,0 -2,-0.9 -2,-2v-6.58l3,2.99 4,-4 4,4 4,-3.99z" />
+</vector>

--- a/app/src/main/res/drawable/ic_image_placeholder.xml
+++ b/app/src/main/res/drawable/ic_image_placeholder.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/darker_gray"
+        android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z" />
+</vector>

--- a/app/src/main/res/layout/fragment_edit_event.xml
+++ b/app/src/main/res/layout/fragment_edit_event.xml
@@ -1,168 +1,224 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:context=".View.EditEventFragment">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".View.EditEventFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
         <!-- Event Name section -->
         <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/text_field_event_name"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="20dp"
-                android:layout_marginTop="40dp"
-                android:layout_marginEnd="20dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:startIconDrawable="@drawable/event_name_icon">
+            android:id="@+id/text_field_event_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="40dp"
+            android:layout_marginEnd="20dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:startIconDrawable="@drawable/event_name_icon">
 
             <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/edit_text_event_name"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:ems="10"
-                    android:hint="@string/event_name_hint"
-                    android:inputType="text"/>
+                android:id="@+id/edit_text_event_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ems="10"
+                android:hint="@string/event_name_hint"
+                android:inputType="text"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <!-- Event location section -->
         <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/text_field_event_location"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/text_field_event_name"
-                app:startIconDrawable="@drawable/event_location_icon">
+            android:id="@+id/text_field_event_location"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/text_field_event_name"
+            app:startIconDrawable="@drawable/event_location_icon">
 
             <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/edit_text_event_location"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:ems="10"
-                    android:hint="@string/event_location_hint"
-                    android:inputType="text"/>
+                android:id="@+id/edit_text_event_location"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ems="10"
+                android:hint="@string/event_location_hint"
+                android:inputType="text"/>
         </com.google.android.material.textfield.TextInputLayout>
 
-        <!-- Event Photo URL section -->
+        <!-- Event Photo section with actual image display -->
+        <TextView
+            android:id="@+id/photo_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Event Photo:"
+            android:textSize="16sp"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="16dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/text_field_event_location"/>
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/event_image_card"
+            android:layout_width="0dp"
+            android:layout_height="200dp"
+            android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp"
+            android:layout_marginTop="8dp"
+            app:cardCornerRadius="8dp"
+            app:cardElevation="4dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/photo_label">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <ImageView
+                    android:id="@+id/event_image_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:scaleType="centerCrop"
+                    android:contentDescription="Event image"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"/>
+
+                <TextView
+                    android:id="@+id/tap_to_change_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Tap to change image"
+                    android:textColor="@android:color/white"
+                    android:background="#80000000"
+                    android:padding="8dp"
+                    android:visibility="visible"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"/>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.cardview.widget.CardView>
+
+        <!-- Hidden field to store the image URL -->
         <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/text_field_event_photo_url"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/text_field_event_location"
-                app:startIconDrawable="@drawable/event_photo_icon">
+            android:id="@+id/text_field_event_photo_url"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp"
+            android:visibility="gone"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/event_image_card">
 
             <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/edit_text_event_photo_url"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:ems="10"
-                    android:hint="@string/event_photo_url_hint"
-                    android:inputType="text"/>
+                android:id="@+id/edit_text_event_photo_url"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ems="10"
+                android:hint="@string/event_photo_url_hint"
+                android:inputType="text"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <!-- Event Date section -->
         <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/text_field_event_date"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/text_field_event_photo_url"
-                app:startIconDrawable="@drawable/event_date_icon">
+            android:id="@+id/text_field_event_date"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp"
+            android:layout_marginTop="16dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/event_image_card"
+            app:startIconDrawable="@drawable/event_date_icon">
 
             <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/edit_text_event_date"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:clickable="true"
-                    android:focusable="false"
-                    android:hint="@string/event_date_hint"/>
+                android:id="@+id/edit_text_event_date"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="false"
+                android:hint="@string/event_date_hint"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <!-- Event Type section -->
         <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/text_field_event_type"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/text_field_event_date"
-                app:startIconDrawable="@drawable/event_type_icon">
+            android:id="@+id/text_field_event_type"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/text_field_event_date"
+            app:startIconDrawable="@drawable/event_type_icon">
 
             <AutoCompleteTextView
-                    android:id="@+id/auto_complete_text_view_event_type"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:hint="@string/event_type_hint"/>
+                android:id="@+id/auto_complete_text_view_event_type"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clickable="true"
+                android:focusable="true"
+                android:hint="@string/event_type_hint"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <!-- Event Description section -->
         <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/text_field_event_description"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/text_field_event_type"
-                app:startIconDrawable="@drawable/event_description_icon">
+            android:id="@+id/text_field_event_description"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/text_field_event_type"
+            app:startIconDrawable="@drawable/event_description_icon">
 
             <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/edit_text_event_description"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:hint="@string/event_description_hint"
-                    android:inputType="textMultiLine"
-                    android:minLines="3"
-                    android:gravity="top"/>
+                android:id="@+id/edit_text_event_description"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/event_description_hint"
+                android:inputType="textMultiLine"
+                android:minLines="3"
+                android:gravity="top"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <LinearLayout
-                android:layout_width="match_parent"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center"
+            android:layout_marginTop="20dp"
+            android:layout_marginBottom="20dp"
+            app:layout_constraintTop_toBottomOf="@id/text_field_event_description"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <Button
+                android:id="@+id/delete_event_button"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:gravity="center"
-                android:layout_marginTop="20dp"
-                app:layout_constraintTop_toBottomOf="@id/text_field_event_description"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent">
+                android:layout_marginEnd="8dp"
+                android:text="Delete"
+                android:backgroundTint="@android:color/holo_red_light"/>
 
             <Button
-                    android:id="@+id/delete_event_button"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="8dp"
-                    android:text="Delete"
-                    android:backgroundTint="@android:color/holo_red_light"/>
-
-            <Button
-                    android:id="@+id/update_event_button"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="8dp"
-                    android:text="@string/button_edit_event"/>
+                android:id="@+id/update_event_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="@string/button_edit_event"/>
         </LinearLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## ✨ Event Photo Support in Edit Event

This pull request adds full support for handling event photos in the `EditEventFragment`. Users can now select or capture a photo for their event, which is then displayed and uploaded automatically.

### 🔧 Key Features
- Allow users to choose an image from the gallery or take a photo with the camera.
- Handle runtime permissions for image selection.
- Display the selected image using **Glide**.
- Upload the new image to **Firebase Storage**.
- Automatically **delete the old image** from storage when a new one is uploaded.

### 🧩 Supporting Changes
- Integrated Glide for image loading.
- Added vector drawables for image placeholders and error states.
- Updated `fragment_edit_event.xml` with an image card, hidden URL field, and a "Tap to change image" label.
- Declared the camera feature as optional in the manifest.

These changes enhance the user experience by enabling smooth and intuitive event photo management.
