### PR TITLE
Geocoding on button instead of when writing

### DIFF
--- a/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/AddEventFragment.kt
+++ b/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/AddEventFragment.kt
@@ -53,6 +53,7 @@ class AddEventFragment : Fragment() {
     // UI Elements
     private lateinit var eventName: EditText
     private lateinit var eventLocation: EditText
+    private lateinit var geocodeButton: Button
     private lateinit var eventPhotoURL: EditText
     private lateinit var eventDate: TextInputEditText
     private lateinit var eventType: AutoCompleteTextView
@@ -149,11 +150,21 @@ class AddEventFragment : Fragment() {
         // Bind UI Elements
         eventName = binding.editTextEventName
         eventLocation = binding.editTextEventLocation
+        geocodeButton = binding.geocodeButton
         eventPhotoURL = binding.editTextEventPhotoUrl
         eventDate = binding.editTextEventDate
         eventType = binding.autoCompleteTextViewEventType
         eventDescription = binding.editTextEventDescription
         addEventButton = binding.addEventButton
+
+        geocodeButton.setOnClickListener{
+            val locationText = eventLocation.text.toString().trim()
+            if (locationText.isNotEmpty()) {
+                geocodeLocation(locationText)
+            } else {
+                showSnackbar("Please enter a location to geocode")
+            }
+        }
 
         // Photo buttons setup
         binding.buttonCapturePhoto.setOnClickListener {
@@ -183,22 +194,6 @@ class AddEventFragment : Fragment() {
             eventTypeDropdown.requestFocus() // Ensure it gets focus
             eventTypeDropdown.showDropDown() // Show dropdown immediately
         }
-
-        // Add a text change listener to the location field for geocoding
-        eventLocation.addTextChangedListener(object : TextWatcher {
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
-
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
-
-            override fun afterTextChanged(s: Editable?) {
-                val locationText = s.toString().trim()
-                if (locationText.length > 3) { // Only geocode if there's enough text
-                    geocodeLocation(locationText)
-                } else {
-                    hasValidCoordinates = false
-                }
-            }
-        })
 
         // Button click listener
         addEventButton.setOnClickListener {

--- a/app/src/main/res/layout/fragment_add_event.xml
+++ b/app/src/main/res/layout/fragment_add_event.xml
@@ -62,11 +62,14 @@
 
         <com.google.android.material.button.MaterialButton
                 android:id="@+id/geocode_button"
-                android:layout_width="wrap_content"
+                android:layout_width="48dp"
                 android:layout_height="wrap_content"
-                android:layout_marginEnd="20dp"
-                android:text="Locate"
+                android:layout_marginEnd="25dp"
+                android:contentDescription="@string/button_geocode"
                 app:icon="@android:drawable/ic_menu_search"
+                app:iconGravity="textStart"
+                app:iconPadding="0dp"
+                app:iconSize="24dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="@+id/text_field_event_location"
                 app:layout_constraintBottom_toBottomOf="@+id/text_field_event_location" />
@@ -188,6 +191,7 @@
             <AutoCompleteTextView
                     android:id="@+id/auto_complete_text_view_event_type"
                     android:layout_width="match_parent"
+                    android:contentDescription="@string/dropdown_event_type"
                     android:layout_height="wrap_content"
                     android:inputType="none" />
 

--- a/app/src/main/res/layout/fragment_add_event.xml
+++ b/app/src/main/res/layout/fragment_add_event.xml
@@ -60,6 +60,17 @@
 
         </com.google.android.material.textfield.TextInputLayout>
 
+        <com.google.android.material.button.MaterialButton
+                android:id="@+id/geocode_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="20dp"
+                android:text="Locate"
+                app:icon="@android:drawable/ic_menu_search"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/text_field_event_location"
+                app:layout_constraintBottom_toBottomOf="@+id/text_field_event_location" />
+
         <!-- Photo capture and selection section -->
         <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/photo_capture_section"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,4 +27,6 @@
     <string name="fragment_maps_name">Maps Fragment</string>
     <string name="favorite_event_image">Image of the favorite event</string>
     <string name="button_edit_event">Edit Event</string>
+    <string name="button_geocode">Locate address on map</string>
+    <string name="dropdown_event_type">Dropdown list of event types</string>
 </resources>


### PR DESCRIPTION
This pull request changes the geocoding done in the AddEventFragment to be when a button is clicked instead of as the user is writing the input. As the implementation beforehand, caused a lot of confusion and lead to more wrong results than correct

![billede](https://github.com/user-attachments/assets/797e38c6-0c95-4293-b80b-5879741a6b9c)
