### PR TITLE
Maps UI and location bug fixes

### DIFF
--- a/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/MapsFragment.kt
+++ b/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/MapsFragment.kt
@@ -16,6 +16,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.location.Location
 import androidx.appcompat.app.AlertDialog
+import com.google.android.gms.location.LocationServices
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.OnMapReadyCallback
@@ -49,6 +50,7 @@ class MapsFragment : Fragment(), LocationBroadcastReceiver.LocationListener, OnM
     private var currentLocation: Location? = null
     private var googleMap: GoogleMap? = null
     private val eventMarkers = mutableMapOf<Marker, Event>()
+    private var doneInitialZoom = false
 
 
 
@@ -206,18 +208,39 @@ class MapsFragment : Fragment(), LocationBroadcastReceiver.LocationListener, OnM
             ) {
                 isMyLocationEnabled = true
                 uiSettings.isMyLocationButtonEnabled = true
+
+                val fusedLocationClient = LocationServices.getFusedLocationProviderClient(requireActivity())
+                fusedLocationClient.lastLocation.addOnSuccessListener { location ->
+                    location?.let {
+                        zoomToLocation(it)
+                        doneInitialZoom = true
+                    }
+                }
             }
         }
 
-        currentLocation?.let { updateMapWithLocation(it) }
+        currentLocation?.let {
+            if(!doneInitialZoom){
+                zoomToLocation(it)
+                doneInitialZoom = true
+            }
+        }
 
         loadEventsFromFirebase()
     }
 
-    private fun updateMapWithLocation(location: Location) {
+    private fun zoomToLocation(location: Location){
         googleMap?.let {
             val currentLatLng = LatLng(location.latitude, location.longitude)
             it.moveCamera(CameraUpdateFactory.newLatLngZoom(currentLatLng, 14f))
+        }
+    }
+
+    private fun updateMapWithLocation(location: Location) {
+        // Update the camera position if initial zoom hasn't happened yet
+        if (!doneInitialZoom) {
+            zoomToLocation(location)
+            doneInitialZoom = true
         }
     }
 

--- a/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/MapsFragment.kt
+++ b/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/MapsFragment.kt
@@ -24,6 +24,7 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
 import com.google.firebase.Firebase
+import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.ValueEventListener
@@ -280,9 +281,14 @@ class MapsFragment : Fragment(), LocationBroadcastReceiver.LocationListener, OnM
     }
 
     private fun showEventDetails(event: Event) {
+        // Checks if the user is logged in or not
+        val isLoggedIn = FirebaseAuth.getInstance().currentUser != null
+
+
         val fragment = EventDetailsFragment().apply {
             arguments = Bundle().apply {
                 putParcelable("event", event)
+                putBoolean("isLoggedIn", isLoggedIn) // Pass the login status to the fragment
             }
         }
 


### PR DESCRIPTION
This Pull Request focuses on fixing an UI bug alongside making sure that the maps fragment zooms in on the user when they launch the app. Though important to note that this only properly works when running on a phone. If ran through the emulator, the maps fragment will take you to San Francisco, as it is an default location provided by the emulator.

### Location Handling Improvements:
* Added `doneInitialZoom` property to ensure the map performs an initial zoom only once, using the user's last known location or the current location. (`[[1]](diffhunk://#diff-63afd27bbee332fba742fbadaff0109c5d990e728b9a768265c314afb252e341R53)`, `[[2]](diffhunk://#diff-63afd27bbee332fba742fbadaff0109c5d990e728b9a768265c314afb252e341R211-R246)`)
* Refactored the `updateMapWithLocation` method to separate concerns by introducing a new `zoomToLocation` method for handling camera updates. (`[app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/MapsFragment.ktR211-R246](diffhunk://#diff-63afd27bbee332fba742fbadaff0109c5d990e728b9a768265c314afb252e341R211-R246)`)

### Firebase Integration:
* Added `FirebaseAuth` import and implemented a check to determine if the user is logged in. This login status is passed to the `EventDetailsFragment` to customize the user experience. (`[[1]](diffhunk://#diff-63afd27bbee332fba742fbadaff0109c5d990e728b9a768265c314afb252e341R28)`, `[[2]](diffhunk://#diff-63afd27bbee332fba742fbadaff0109c5d990e728b9a768265c314afb252e341R307-R314)`)

### Codebase Enhancements:
* Added `LocationServices` import to utilize `FusedLocationProviderClient` for retrieving the user's last known location. (`[app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/MapsFragment.ktR19](diffhunk://#diff-63afd27bbee332fba742fbadaff0109c5d990e728b9a768265c314afb252e341R19)`)

## Preview
![billede](https://github.com/user-attachments/assets/e1d817b5-c6bb-45eb-8f31-87b5000e9b0b)
