### PR TITLE
Fixed socials buttons for events when anonymous

### DIFF
--- a/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/EventAdapter.kt
+++ b/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/EventAdapter.kt
@@ -95,7 +95,7 @@ class EventAdapter : BaseAdapter {
 
     override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View {
         // Check authentication status before rendering view
-        updateLoginStatus()
+        // updateLoginStatus()
 
         val view = convertView ?: LayoutInflater.from(context).inflate(layoutResId, parent, false)
         val binding: ViewBinding
@@ -119,15 +119,9 @@ class EventAdapter : BaseAdapter {
     }
 
     // Method to update login status
-    private fun updateLoginStatus() {
+    /*private fun updateLoginStatus() {
         isLoggedIn = auth.currentUser != null
-    }
-
-    // Public method to force update login status
-    fun refreshLoginStatus() {
-        updateLoginStatus()
-        notifyDataSetChanged()
-    }
+    }*/
 
     private fun populateView(view: View, event: Event, eventKey: String) {
         val binding = (view.tag as ViewHolder).binding

--- a/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/EventDetailsFragment.kt
+++ b/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/EventDetailsFragment.kt
@@ -33,7 +33,7 @@ class EventDetailsFragment : BottomSheetDialogFragment() {
                 @Suppress("DEPRECATION")
                 it.getParcelable("event") ?: Event()
             }
-            isLoggedIn = it.getBoolean("isLoggedIn")
+            isLoggedIn = requireActivity().intent.getBooleanExtra("isLoggedIn", false)
         }
 
     }


### PR DESCRIPTION
This pull request refactors the handling of user authentication status in the `EventAdapter` and `EventDetailsFragment` classes by removing redundant methods and simplifying logic. The changes aim to streamline the codebase and reduce unnecessary updates.

### Refactoring of authentication status handling:

* [`app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/EventAdapter.kt`](diffhunk://#diff-32c7e905eb990043716b2d6abc405793b74ac4dd8d509383cfb26cf869ae1115L98-R98): Commented out the `updateLoginStatus` method and its invocation in `getView`, effectively deprecating it. Additionally, removed the `refreshLoginStatus` method, which was used to force updates and refresh the view. [[1]](diffhunk://#diff-32c7e905eb990043716b2d6abc405793b74ac4dd8d509383cfb26cf869ae1115L98-R98) [[2]](diffhunk://#diff-32c7e905eb990043716b2d6abc405793b74ac4dd8d509383cfb26cf869ae1115L122-R124)

* [`app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/EventDetailsFragment.kt`](diffhunk://#diff-4338177af2bf8eb9baf2e0e44186db3450f668d8fb320d88b359c36ce5693506L36-R36): Simplified the `isLoggedIn` property initialization by replacing the `Bundle`-based retrieval with a direct intent-based approach using `requireActivity().intent.getBooleanExtra`.