### PR TITLE
Maps be able to favorite

### DIFF
--- a/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/EventDetailsFragment.kt
+++ b/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/EventDetailsFragment.kt
@@ -35,7 +35,7 @@ class EventDetailsFragment : BottomSheetDialogFragment() {
                 it.getParcelable("event") ?: Event()
             }
             eventKey = it.getString("eventKey","")
-            isLoggedIn = requireActivity().intent.getBooleanExtra("isLoggedIn", false)
+            isLoggedIn = it.getBoolean("isLoggedIn", false)
         }
 
     }

--- a/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/EventDetailsFragment.kt
+++ b/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/EventDetailsFragment.kt
@@ -22,6 +22,7 @@ class EventDetailsFragment : BottomSheetDialogFragment() {
 
     private lateinit var binding: FragmentEventDetailsBinding
     private lateinit var event: Event
+    private var eventKey: String = ""
     private var isLoggedIn: Boolean = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -33,6 +34,7 @@ class EventDetailsFragment : BottomSheetDialogFragment() {
                 @Suppress("DEPRECATION")
                 it.getParcelable("event") ?: Event()
             }
+            eventKey = it.getString("eventKey","")
             isLoggedIn = it.getBoolean("isLoggedIn")
         }
 
@@ -80,11 +82,6 @@ class EventDetailsFragment : BottomSheetDialogFragment() {
                 favoriteButton.setOnClickListener {
                     toggleFavorite()
                 }
-
-                // Add share button functionality
-                shareButton.setOnClickListener {
-                    shareEvent()
-                }
             }
 
 
@@ -104,21 +101,21 @@ class EventDetailsFragment : BottomSheetDialogFragment() {
         val favoritesRef = database.getReference("Favorites").child(userId)
 
         // Check if this event is already a favorite
-        favoritesRef.child(event.eventName).get().addOnSuccessListener { dataSnapshot ->
+        favoritesRef.child(eventKey).get().addOnSuccessListener { dataSnapshot ->
             if (dataSnapshot.exists()) {
                 // Event is already favorited, so remove it
-                removeFromFavorites(userId, favoritesRef)
+                removeFromFavorites(favoritesRef)
             } else {
                 // Event is not favorited, so add it
-                addToFavorites(userId, favoritesRef)
+                addToFavorites(favoritesRef)
             }
         }.addOnFailureListener { e ->
             showSnackbar("Error accessing favorites: ${e.message}")
         }
     }
 
-    private fun addToFavorites(userId: String, favoritesRef: DatabaseReference) {
-        favoritesRef.child(event.eventName).setValue(event)
+    private fun addToFavorites(favoritesRef: DatabaseReference) {
+        favoritesRef.child(eventKey).setValue(true)
             .addOnSuccessListener {
                 showSnackbar("Added to favorites")
             }
@@ -127,42 +124,14 @@ class EventDetailsFragment : BottomSheetDialogFragment() {
             }
     }
 
-    private fun removeFromFavorites(userId: String, favoritesRef: DatabaseReference) {
-        favoritesRef.child(event.eventName).removeValue()
+    private fun removeFromFavorites(favoritesRef: DatabaseReference) {
+        favoritesRef.child(eventKey).removeValue()
             .addOnSuccessListener {
                 showSnackbar("Removed from favorites")
             }
             .addOnFailureListener { e ->
                 showSnackbar("Failed to remove event from favorites: ${e.message}")
             }
-    }
-
-    private fun shareEvent() {
-        // Format date for sharing
-        val date = Date(event.eventDate)
-        val formattedDate = SimpleDateFormat("dd MMM yyyy", Locale.getDefault()).format(date)
-
-        // Create share text
-        val shareText = """
-            Check out this event in Copenhagen!
-            
-            ${event.eventName}
-            Date: $formattedDate
-            Location: ${event.eventLocation.address}
-            Type: ${event.eventType}
-            
-            ${event.eventDescription}
-        """.trimIndent()
-
-        // Create share intent
-        val sendIntent = android.content.Intent().apply {
-            action = android.content.Intent.ACTION_SEND
-            putExtra(android.content.Intent.EXTRA_TEXT, shareText)
-            type = "text/plain"
-        }
-
-        val shareIntent = android.content.Intent.createChooser(sendIntent, null)
-        startActivity(shareIntent)
     }
 
     private fun showSnackbar(message: String) {

--- a/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/EventDetailsFragment.kt
+++ b/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/EventDetailsFragment.kt
@@ -82,11 +82,6 @@ class EventDetailsFragment : BottomSheetDialogFragment() {
                 favoriteButton.setOnClickListener {
                     toggleFavorite()
                 }
-
-                // Add share button functionality
-                shareButton.setOnClickListener {
-                    shareEvent()
-                }
             }
 
 
@@ -106,21 +101,21 @@ class EventDetailsFragment : BottomSheetDialogFragment() {
         val favoritesRef = database.getReference("Favorites").child(userId)
 
         // Check if this event is already a favorite
-        favoritesRef.child(event.eventName).get().addOnSuccessListener { dataSnapshot ->
+        favoritesRef.child(eventKey).get().addOnSuccessListener { dataSnapshot ->
             if (dataSnapshot.exists()) {
                 // Event is already favorited, so remove it
-                removeFromFavorites(userId, favoritesRef)
+                removeFromFavorites(favoritesRef)
             } else {
                 // Event is not favorited, so add it
-                addToFavorites(userId, favoritesRef)
+                addToFavorites(favoritesRef)
             }
         }.addOnFailureListener { e ->
             showSnackbar("Error accessing favorites: ${e.message}")
         }
     }
 
-    private fun addToFavorites(userId: String, favoritesRef: DatabaseReference) {
-        favoritesRef.child(event.eventName).setValue(event)
+    private fun addToFavorites(favoritesRef: DatabaseReference) {
+        favoritesRef.child(eventKey).setValue(true)
             .addOnSuccessListener {
                 showSnackbar("Added to favorites")
             }
@@ -129,42 +124,14 @@ class EventDetailsFragment : BottomSheetDialogFragment() {
             }
     }
 
-    private fun removeFromFavorites(userId: String, favoritesRef: DatabaseReference) {
-        favoritesRef.child(event.eventName).removeValue()
+    private fun removeFromFavorites(favoritesRef: DatabaseReference) {
+        favoritesRef.child(eventKey).removeValue()
             .addOnSuccessListener {
                 showSnackbar("Removed from favorites")
             }
             .addOnFailureListener { e ->
                 showSnackbar("Failed to remove event from favorites: ${e.message}")
             }
-    }
-
-    private fun shareEvent() {
-        // Format date for sharing
-        val date = Date(event.eventDate)
-        val formattedDate = SimpleDateFormat("dd MMM yyyy", Locale.getDefault()).format(date)
-
-        // Create share text
-        val shareText = """
-            Check out this event in Copenhagen!
-            
-            ${event.eventName}
-            Date: $formattedDate
-            Location: ${event.eventLocation.address}
-            Type: ${event.eventType}
-            
-            ${event.eventDescription}
-        """.trimIndent()
-
-        // Create share intent
-        val sendIntent = android.content.Intent().apply {
-            action = android.content.Intent.ACTION_SEND
-            putExtra(android.content.Intent.EXTRA_TEXT, shareText)
-            type = "text/plain"
-        }
-
-        val shareIntent = android.content.Intent.createChooser(sendIntent, null)
-        startActivity(shareIntent)
     }
 
     private fun showSnackbar(message: String) {

--- a/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/MapsFragment.kt
+++ b/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/MapsFragment.kt
@@ -49,8 +49,9 @@ class MapsFragment : Fragment(), LocationBroadcastReceiver.LocationListener, OnM
     private var locationReceiver: LocationBroadcastReceiver? = null
     private var currentLocation: Location? = null
     private var googleMap: GoogleMap? = null
-    private val eventMarkers = mutableMapOf<Marker, Event>()
     private var doneInitialZoom = false
+    private val eventMarkers = mutableMapOf<Marker, Event>()
+    private val eventKeys = mutableMapOf<Event, String>()
 
 
 
@@ -257,15 +258,19 @@ class MapsFragment : Fragment(), LocationBroadcastReceiver.LocationListener, OnM
 
         eventsRef.addValueEventListener(object: ValueEventListener {
             override fun onDataChange(snapshot: DataSnapshot) {
-
-                // Clears existing event markers
+                // Clear existing event markers and keys
                 eventMarkers.keys.forEach { it.remove() }
                 eventMarkers.clear()
+                eventKeys.clear()
 
-                // Adds new event markers for each event in the database
+                // Add new event markers for each event in the database
                 for (eventSnapshot in snapshot.children) {
                     val event = eventSnapshot.getValue(Event::class.java)
-                    event?.let {addEventMarker(it)}
+                    val key = eventSnapshot.key
+                    if (event != null && key != null) {
+                        addEventMarker(event)
+                        eventKeys[event] = key
+                    }
                 }
             }
 
@@ -307,11 +312,14 @@ class MapsFragment : Fragment(), LocationBroadcastReceiver.LocationListener, OnM
         // Checks if the user is logged in or not
         val isLoggedIn = FirebaseAuth.getInstance().currentUser != null
 
+        // Get the event key from our map
+        val eventKey = eventKeys[event] ?: ""
 
         val fragment = EventDetailsFragment().apply {
             arguments = Bundle().apply {
                 putParcelable("event", event)
-                putBoolean("isLoggedIn", isLoggedIn) // Pass the login status to the fragment
+                putBoolean("isLoggedIn", isLoggedIn)
+                putString("eventKey", eventKey) // Add the event key
             }
         }
 

--- a/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/MapsFragment.kt
+++ b/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/MapsFragment.kt
@@ -310,7 +310,8 @@ class MapsFragment : Fragment(), LocationBroadcastReceiver.LocationListener, OnM
 
     private fun showEventDetails(event: Event) {
         // Checks if the user is logged in or not
-        val isLoggedIn = FirebaseAuth.getInstance().currentUser != null
+        val currentUser = FirebaseAuth.getInstance().currentUser
+        val isLoggedIn = currentUser != null && !currentUser.isAnonymous
 
         // Get the event key from our map
         val eventKey = eventKeys[event] ?: ""

--- a/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/NearYouFragment.kt
+++ b/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/NearYouFragment.kt
@@ -17,6 +17,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Observer
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
+import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.DatabaseReference
@@ -228,7 +229,8 @@ class NearYouFragment : Fragment() {
             return
         }
 
-        val isLoggedIn = requireActivity().intent.getBooleanExtra("isLoggedIn", false)
+        val currentUser = FirebaseAuth.getInstance().currentUser
+        val isLoggedIn = currentUser != null && !currentUser.isAnonymous
 
         // Remove any existing listener before adding a new one
         removeEventListener()

--- a/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/TimelineFragment.kt
+++ b/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/TimelineFragment.kt
@@ -18,6 +18,7 @@ import io.github.cdimascio.dotenv.dotenv
 import com.google.firebase.database.ktx.database
 import com.google.firebase.ktx.Firebase
 import dk.itu.moapd.copenhagenbuzz.ralc.nhca.Model.Event
+import com.google.firebase.auth.FirebaseAuth
 
 /**
  * A simple [Fragment] subclass that displays a timeline of events.
@@ -53,7 +54,8 @@ class TimelineFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         listView = view.findViewById(R.id.event_list_view)
-        isLoggedIn = requireActivity().intent.getBooleanExtra("isLoggedIn", false)
+        val currentUser = FirebaseAuth.getInstance().currentUser
+        isLoggedIn = currentUser != null && !currentUser.isAnonymous
 
         // Load data on first creation
         loadEventsData()


### PR DESCRIPTION
This pull request fixes the favorite functionality in the maps fragment. As before you couldn't actually favorite an event in the maps fragment. Now you can favorite an unfavorite events as expected. The pull request also refixes the login, as it did properly show the UI correctly for the guest, but if you were logged in through Google for example, closed and reopened the app, you saw the UI as the guest. 

### Event Handling Improvements:
* Added `eventKey` to `EventDetailsFragment` and updated logic to use `eventKey` instead of `eventName` for identifying events in Firebase operations. (`EventDetailsFragment.kt`, [[1]](diffhunk://#diff-4338177af2bf8eb9baf2e0e44186db3450f668d8fb320d88b359c36ce5693506R25) [[2]](diffhunk://#diff-4338177af2bf8eb9baf2e0e44186db3450f668d8fb320d88b359c36ce5693506L36-R38) [[3]](diffhunk://#diff-4338177af2bf8eb9baf2e0e44186db3450f668d8fb320d88b359c36ce5693506L107-R118) [[4]](diffhunk://#diff-4338177af2bf8eb9baf2e0e44186db3450f668d8fb320d88b359c36ce5693506L130-R128)
* Introduced `eventKeys` map in `MapsFragment` to store event keys alongside event objects and updated event marker handling to clear both markers and keys. (`MapsFragment.kt`, [[1]](diffhunk://#diff-63afd27bbee332fba742fbadaff0109c5d990e728b9a768265c314afb252e341L52-R54) [[2]](diffhunk://#diff-63afd27bbee332fba742fbadaff0109c5d990e728b9a768265c314afb252e341L260-R273)
* Updated `showEventDetails` in `MapsFragment` to pass the `eventKey` to `EventDetailsFragment`. (`MapsFragment.kt`, [app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/MapsFragment.ktL308-R323](diffhunk://#diff-63afd27bbee332fba742fbadaff0109c5d990e728b9a768265c314afb252e341L308-R323))

### Authentication Enhancements:
* Updated authentication checks in `EventDetailsFragment`, `NearYouFragment`, and `TimelineFragment` to ensure anonymous users are not treated as logged-in users. (`EventDetailsFragment.kt`, [[1]](diffhunk://#diff-4338177af2bf8eb9baf2e0e44186db3450f668d8fb320d88b359c36ce5693506L36-R38); `NearYouFragment.kt`, [[2]](diffhunk://#diff-e55cda4cd467957e5c37343f6247f081ab46ecff6ddd62d2762649d374f2fe5aL231-R233); `TimelineFragment.kt`, [[3]](diffhunk://#diff-e0c37c5b493d145a39cdfe23740a2abba5b67a0e5c4c17552aabae06f46cd323L56-R58)

### Feature Removal:
* Removed the event sharing functionality from `EventDetailsFragment`, including the `shareEvent` method and its associated UI logic. (`EventDetailsFragment.kt`, [[1]](diffhunk://#diff-4338177af2bf8eb9baf2e0e44186db3450f668d8fb320d88b359c36ce5693506L83-L87) [[2]](diffhunk://#diff-4338177af2bf8eb9baf2e0e44186db3450f668d8fb320d88b359c36ce5693506L140-L167)