### PR TITLE
Refactor/use view model

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -122,5 +122,6 @@ dependencies {
 
     // Compose but Coil (picasso of Compose)
     implementation(libs.coil.compose)
+    implementation("androidx.compose.runtime:runtime-livedata:1.5.4")
 
 }

--- a/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/EventAdapter.kt
+++ b/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/EventAdapter.kt
@@ -302,7 +302,6 @@ class EventAdapter : BaseAdapter {
 
             // Conditionally render buttons
             buttonFavorite.visibility = if (isLoggedIn) View.VISIBLE else View.GONE
-            buttonShare.visibility = if (isLoggedIn) View.VISIBLE else View.GONE
             // Show edit button only if the current user is the creator of the event
             editButton.visibility = if (isCreator) View.VISIBLE else View.GONE
 
@@ -375,7 +374,6 @@ class EventAdapter : BaseAdapter {
 
             // Conditionally render buttons
             buttonFavorite.visibility = if (isLoggedIn) View.VISIBLE else View.GONE
-            buttonShare.visibility = if (isLoggedIn) View.VISIBLE else View.GONE
             // Show edit button only if the current user is the creator of the event
             editButton.visibility = if (isCreator) View.VISIBLE else View.GONE
 

--- a/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/EventAdapter.kt
+++ b/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/View/EventAdapter.kt
@@ -1,6 +1,7 @@
 package dk.itu.moapd.copenhagenbuzz.ralc.nhca.View
 
 import android.content.Context
+import android.graphics.BlendModeColorFilter
 import android.view.View
 import android.graphics.Color
 import android.os.Bundle
@@ -255,7 +256,9 @@ class EventAdapter : BaseAdapter {
 
             // Change favorite icon color if the event is in the favoriteEvents list
             if (favoriteEvents.contains(event)) {
-                buttonFavorite.icon.setColorFilter(Color.RED, android.graphics.PorterDuff.Mode.SRC_IN)
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                    buttonFavorite.icon.colorFilter = BlendModeColorFilter(Color.RED, android.graphics.BlendMode.SRC_IN)
+                }
             } else {
                 buttonFavorite.icon.clearColorFilter()
             }
@@ -323,7 +326,9 @@ class EventAdapter : BaseAdapter {
 
             // Change favorite icon color if the event is in the favoriteEvents list
             if (favoriteEvents.contains(event)) {
-                buttonFavorite.icon.setColorFilter(Color.RED, android.graphics.PorterDuff.Mode.SRC_IN)
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                    buttonFavorite.icon.colorFilter = BlendModeColorFilter(Color.RED, android.graphics.BlendMode.SRC_IN)
+                }
             } else {
                 buttonFavorite.icon.clearColorFilter()
             }

--- a/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/ViewModel/DataViewModel.kt
+++ b/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/ViewModel/DataViewModel.kt
@@ -20,62 +20,20 @@ class DataViewModel : ViewModel() {
     _events is a MutableLiveData object that holds a list of Event objects.
     events is a LiveData object that provides read-only access to the list of events.
     */
-    private val _events = MutableLiveData<List<Event>>()
+    private val _events = MutableLiveData<List<Event>>(emptyList())
     val events: LiveData<List<Event>>
         get() = _events
 
-    private val _favoriteEvents = MutableLiveData<List<Event>>()
+    private val _favoriteEvents = MutableLiveData<List<Event>>(emptyList())
     val favoriteEvents: LiveData<List<Event>>
         get() = _favoriteEvents
 
-    private val faker = Faker()
-    val dateFormat = SimpleDateFormat("dd-MM-yyyy", Locale.getDefault())
-
-    /*init {
-        fetchEvents()
-    }*/
-
-    private fun generateRandomFavorites (events: List<Event>): List<Event> {
-        val shuffledIndices = (events.indices).shuffled().take(10).sorted()
-        return shuffledIndices.mapNotNull { index -> events.getOrNull(index) }
-    }
-
     /**
-     * Generates and fetches the list of events asynchronously.
-     */
-    /*private fun fetchEvents() {
-        viewModelScope.launch {
-            val eventList = generateEvents()
-            _events.value = eventList
-            _favoriteEvents.value = generateRandomFavorites(eventList)
-        }
-    }*/
-
-    /**
-     * Generates a list of events.
+     * Updates the list of favorite events.
      *
-     * @return A list of Event objects.
+     * @param newFavorites The new list of favorite events to store.
      */
-    /*private suspend fun generateEvents(): List<Event> {
-        return withContext(Dispatchers.Default) {
-            // Simulate generating a list of events
-            val faker = Faker()
-            return@withContext List(20) { _ ->
-                val fakeDate = faker.date().birthday()
-                val timestamp = fakeDate.time
-
-                Event(
-                    creatorUserId = faker.number().randomNumber().toString(),
-                    eventName = faker.lorem().sentence(1),
-                    eventLocation = faker.address().cityName(),
-                    eventPhotoURL = "https://picsum.photos/300/200?random=${System.currentTimeMillis()}",
-                    eventDate = timestamp,
-                    eventType = faker.book().genre(),
-                    eventDescription = faker.lorem().sentence(10)
-                )
-            }
-        }
-    }*/
-
-
+    fun updateFavoriteEvents(newFavorites: List<Event>) {
+        _favoriteEvents.value = newFavorites
+    }
 }

--- a/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/ViewModel/DataViewModel.kt
+++ b/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/ViewModel/DataViewModel.kt
@@ -6,13 +6,19 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import dk.itu.moapd.copenhagenbuzz.ralc.nhca.Model.Event
+import dk.itu.moapd.copenhagenbuzz.ralc.nhca.Model.EventLocation
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
-import com.github.javafaker.Faker
-import java.text.SimpleDateFormat
+import android.net.Uri
 import java.util.*
+import com.google.firebase.Firebase
+import com.google.firebase.database.database
+import com.google.firebase.storage.FirebaseStorage
+import kotlinx.coroutines.tasks.await
+import android.location.Geocoder
+import io.github.cdimascio.dotenv.dotenv
 
 class DataViewModel : ViewModel() {
 
@@ -28,6 +34,20 @@ class DataViewModel : ViewModel() {
     val favoriteEvents: LiveData<List<Event>>
         get() = _favoriteEvents
 
+    // Add event status
+    private val _addEventStatus = MutableLiveData<Resource<Boolean>>()
+    val addEventStatus: LiveData<Resource<Boolean>> = _addEventStatus
+
+    // Upload status
+    private val _uploadStatus = MutableLiveData<Resource<String>>()
+    val uploadStatus: LiveData<Resource<String>> = _uploadStatus
+
+    // Geocode status
+    private val _geocodeStatus = MutableLiveData<Resource<EventLocation>>()
+    val geocodeStatus: LiveData<Resource<EventLocation>> = _geocodeStatus
+
+
+
     /**
      * Updates the list of favorite events.
      *
@@ -36,4 +56,87 @@ class DataViewModel : ViewModel() {
     fun updateFavoriteEvents(newFavorites: List<Event>) {
         _favoriteEvents.value = newFavorites
     }
+
+    /**
+     * Uploads an image to Firebase Storage
+     */
+    fun uploadEventImage(imageUri: Uri) {
+        _uploadStatus.value = Resource.Loading()
+        viewModelScope.launch {
+            try {
+                val storageRef = FirebaseStorage.getInstance().reference
+                val photoRef = storageRef.child("event_photos/${UUID.randomUUID()}")
+
+                // Use withContext to perform IO operations
+                withContext(Dispatchers.IO) {
+                    val uploadTask = photoRef.putFile(imageUri).await()
+                    val downloadUrl = photoRef.downloadUrl.await().toString()
+                    _uploadStatus.postValue(Resource.Success(downloadUrl))
+                }
+            } catch (e: Exception) {
+                _uploadStatus.postValue(Resource.Error("Upload failed: ${e.message}"))
+            }
+        }
+    }
+
+    /**
+     * Geocodes a location address
+     */
+    fun geocodeLocation(locationText: String, geocoder: Geocoder) {
+        _geocodeStatus.value = Resource.Loading()
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val addressList = geocoder.getFromLocationName(locationText, 1)
+
+                if (!addressList.isNullOrEmpty()) {
+                    val address = addressList[0]
+                    val formattedAddress = address.getAddressLine(0) ?: locationText
+                    val eventLocation = EventLocation(
+                        address.latitude,
+                        address.longitude,
+                        formattedAddress
+                    )
+                    _geocodeStatus.postValue(Resource.Success(eventLocation))
+                } else {
+                    _geocodeStatus.postValue(Resource.Error("Location not found"))
+                }
+            } catch (e: Exception) {
+                _geocodeStatus.postValue(Resource.Error("Geocoding error: ${e.message}"))
+            }
+        }
+    }
+
+    /**
+     * Saves event to Firebase
+     */
+    fun saveEventToFirebase(event: Event) {
+        _addEventStatus.value = Resource.Loading()
+        viewModelScope.launch {
+            try {
+                val dotenv = dotenv {
+                    directory = "./assets"
+                    filename = "env"
+                }
+
+                val database = Firebase.database(dotenv["DATABASE_URL"])
+                val eventsRef = database.getReference("Events")
+
+                withContext(Dispatchers.IO) {
+                    eventsRef.push().setValue(event).await()
+                    _addEventStatus.postValue(Resource.Success(true))
+                }
+            } catch (e: Exception) {
+                _addEventStatus.postValue(Resource.Error("Failed to save event: ${e.message}"))
+            }
+        }
+    }
+}
+
+/**
+ * Resource class to handle data states
+ */
+sealed class Resource<T> {
+    class Loading<T> : Resource<T>()
+    data class Success<T>(val data: T) : Resource<T>()
+    data class Error<T>(val message: String) : Resource<T>()
 }

--- a/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/ViewModel/DataViewModel.kt
+++ b/app/src/main/java/dk/itu/moapd/copenhagenbuzz/ralc/nhca/ViewModel/DataViewModel.kt
@@ -69,7 +69,7 @@ class DataViewModel : ViewModel() {
 
                 // Use withContext to perform IO operations
                 withContext(Dispatchers.IO) {
-                    val uploadTask = photoRef.putFile(imageUri).await()
+                    photoRef.putFile(imageUri).await()
                     val downloadUrl = photoRef.downloadUrl.await().toString()
                     _uploadStatus.postValue(Resource.Success(downloadUrl))
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ playServicesLocation = "21.0.1"
 playServicesLocationVersion = "21.3.0"
 playServicesMaps = "19.1.0"
 runtime = "1.5.4"
+runtimeLivedata = "1.5.4"
 secretsGradlePlugin = "2.0.1"
 ui = "1.5.4"
 
@@ -47,6 +48,7 @@ androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycleViewmodelKtx" }
 androidx-material = { module = "androidx.compose.material:material", version.ref = "androidxMaterial" }
 androidx-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "runtime" }
+androidx-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata", version.ref = "runtimeLivedata" }
 androidx-ui = { module = "androidx.compose.ui:ui", version.ref = "ui" }
 androidx-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "ui" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }


### PR DESCRIPTION
## Pull Request Overview

This pull request brings several improvements to both `AddEventFragment` and `EventAdapter`, with a focus on better state management, a streamlined event creation flow, and enhanced handling of user favorites. A minor dependency update is also included.

---

###  `AddEventFragment` Enhancements

- **ViewModel Integration**  
  Introduced `DataViewModel` to manage:
  - Geocoding  
  - Image uploads  
  - Event-saving workflows  
  The fragment now observes `geocodeStatus`, `uploadStatus`, and `addEventStatus` to provide responsive feedback on success, error, or loading states.

- **Geocoding Refactor**  
  Replaced manual geocoding logic with `viewModel.geocodeLocation`.  
  Removed redundant methods such as `geocodeLocation` and `reverseGeocode`.

- **Event-Saving Workflow**  
  Updated to use `viewModel.saveEventToFirebase`, incorporating image uploads via the ViewModel.  
  Deprecated older Firebase-specific saving methods.

---

###  `EventAdapter` Improvements

- **Favorites Handling**  
  Added `favoriteEventKeys` to track favorite events.  
  Introduced `loadFavorites()` to load favorites for the currently logged-in user.  
  Favorite icon logic now reflects actual favorite status.

- **Dynamic Key Retrieval**  
  Added `getEventKeyAt()` method to support retrieving event keys dynamically, depending on whether the adapter uses a sorted list or Firebase query.

---

###  Other Changes

- **Gradle Dependency Update**  
  Added `androidx.compose.runtime:runtime-livedata:1.5.4` to support LiveData integration with Jetpack Compose.
